### PR TITLE
Fix runtests.jl for Julia v1.0

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,2 @@
 using Seaborn
-using Base.Test
+using Test


### PR DESCRIPTION
This is a trivial modification that can be merged right away.

I use this opportunity to ask what is the status of the package in Julia v1.0? There are no tests to run.